### PR TITLE
Persistant db migration

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,9 +10,9 @@ psycopg2-binary = "*"  # PostgreSQL dependency
 django-environ = "*"
 django-cors-headers = "*"
 djangorestframework-simplejwt = "*"
+dj-database-url = "*"
 
 [dev-packages]
 
 [requires]
 python_version = "3.12"
-

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9f79aa8768b7dc82880c0d65fb87d182349ae87f59d4c09604a3428ad759f607"
+            "sha256": "d6e20ba7b36e51da7cdaaefe39c2cb4d824fec1684b57f58c0a78efca194678b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -23,6 +23,14 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==3.8.1"
+        },
+        "dj-database-url": {
+            "hashes": [
+                "sha256:ae52e8e634186b57e5a45e445da5dc407a819c2ceed8a53d1fac004cc5288787",
+                "sha256:bb0d414ba0ac5cd62773ec7f86f8cc378a9dbb00a80884c2fc08cc570452521e"
+            ],
+            "index": "pypi",
+            "version": "==2.3.0"
         },
         "django": {
             "hashes": [
@@ -159,6 +167,14 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==0.5.3"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
+                "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==4.12.2"
         },
         "tzdata": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -73,3 +73,18 @@ Tested retroactive updates and status change from git.
 ```sh
 docker-compose up -d
 
+stop without losing data
+docker-compose down
+
+Check if a user exists
+
+docker exec -it desd-aai-y3-group10-django_app-1 python manage.py shell
+
+from claims.models import CustomUser
+print(CustomUser.objects.all())  # Should list all users
+exit()
+
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -62,3 +62,14 @@ git commit -m "Fix bug in authentication SCRUM-456"
 git push origin main
 
 Tested retroactive updates and status change from git.
+
+### User Persistence & Automated Setup
+
+- **Users now persist across restarts** – Any new users added via Django Admin, API, or shell will be saved in the PostgreSQL database.
+- **User creation is automated** – On a fresh setup, default test users will be created automatically.
+- **Updated `docker-compose.yml`** – The startup process now runs migrations and ensures users exist before launching the app.
+
+#### How to Start the Project:
+```sh
+docker-compose up -d
+

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Tested retroactive updates and status change from git.
 
 #### How to Start the Project:
 ```sh
-docker-compose up -d
+docker-compose up --build -d
 
 stop without losing data
 docker-compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       POSTGRES_PASSWORD: password
     ports:
       - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data  # Persistent storage for DB
     healthcheck:
       test: ["CMD", "pg_isready", "-U", "user"]
       interval: 10s
@@ -30,5 +32,11 @@ services:
       - DATABASE_USER=user
       - DATABASE_PASSWORD=password
       - DATABASE_HOST=postgres_db  # Updated to PostgreSQL service name
-      - DATABASE_PORT=5432  # pdated to PostgreSQL port
-    command: ["python", "manage.py", "runserver", "0.0.0.0:8000"]
+      - DATABASE_PORT=5432  # Updated to PostgreSQL port
+    command: >
+      sh -c "python manage.py migrate &&
+             python manage.py loaddata default_users.json || python manage.py create_users || true &&
+             python manage.py runserver 0.0.0.0:8000"
+
+volumes:
+  postgres_data:  # Named volume to persist PostgreSQL data

--- a/insurance_ai/settings.py
+++ b/insurance_ai/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/5.1/ref/settings/
 
 from pathlib import Path
 import os
+import dj_database_url  # Added for simplified database config
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent  # Ensure BASE_DIR is defined first
@@ -73,16 +74,10 @@ WSGI_APPLICATION = 'insurance_ai.wsgi.application'
 # https://docs.djangoproject.com/en/5.1/ref/settings/#databases
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'insurance_ai',
-        'USER': 'user',
-        'PASSWORD': 'password',
-        'HOST': 'postgres_db',  # PostgreSQL service name in docker-compose.yml
-        'PORT': '5432',
-    }
+    'default': dj_database_url.config(
+        default=f"postgres://{os.getenv('DATABASE_USER')}:{os.getenv('DATABASE_PASSWORD')}@{os.getenv('DATABASE_HOST')}:{os.getenv('DATABASE_PORT')}/{os.getenv('DATABASE_NAME')}"
+    )
 }
-
 
 # Password validation
 # https://docs.djangoproject.com/en/5.1/ref/settings/#auth-password-validators
@@ -115,7 +110,6 @@ USE_TZ = True
 STATIC_URL = '/static/'
 STATICFILES_DIRS = [BASE_DIR / 'staticfiles']
 STATIC_ROOT = BASE_DIR / 'static'
-
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.1/ref/settings/#default-auto-field


### PR DESCRIPTION
Postgre now creates/mounts db that:

handles migrations automatically

will cause persistent changes as long as you are merely using 'docker-compose down' to close

and 'docker-compose up' to restart when you restart work. Changes will only be persistent if you have not changed the database structure/rebuilt the containers.